### PR TITLE
Made InvalidArgumentException extend \InvalidArgumentException

### DIFF
--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -11,6 +11,6 @@
 
 namespace Cache\Adapter\Common\Exception;
 
-class InvalidArgumentException extends \Exception implements \Psr\Cache\InvalidArgumentException
+class InvalidArgumentException extends \InvalidArgumentException implements \Psr\Cache\InvalidArgumentException
 {
 }


### PR DESCRIPTION
This isn't part of the specification (but I think that it should have been).

Otherwise to guarantee catch an invalid argument exception from a block of code you need two catch statements.
